### PR TITLE
Fix Link physical layout ordering to match matrix transform

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -56,10 +56,12 @@ include:
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: cerberus_studio
   - board: link_right
+  + shield: nice_view
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: link_right_studio
   - board: link_left
+  + shield: nice_view
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: link_left_studio  

--- a/build.yaml
+++ b/build.yaml
@@ -56,12 +56,12 @@ include:
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: cerberus_studio
   - board: link_right
-  + shield: nice_view
+    shield: nice_view
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: link_right_studio
   - board: link_left
-  + shield: nice_view
+    shield: nice_view
     snippet: studio-rpc-usb-uart
     cmake-args: -DCONFIG_ZMK_STUDIO=y
     artifact-name: link_left_studio  


### PR DESCRIPTION
## Summary
  - The `physical-layout` entries in `boards/arm/link/link-layouts.dtsi` were grouped by Y-stagger within each row
  instead of following the left-to-right reading order of the matrix transform map.
  - ZMK pairs the Nth physical-layout entry with the Nth transform map entry (and thus the Nth keymap binding), so
  Studio rendered the correct board shape but assigned keycodes to the wrong physical keys (e.g. GRAVE landed on the
  middle-finger column at `(300, 0)` instead of the outer-left pinky at `(0, 36)`).
  - Reordered all 60 entries into reading order, with the two encoder buttons slotted between `B` and `N` to match the
  transform's `RC(4,0)` / `RC(4,11)` placement in row 3.

  ## Test plan
  - [ ] Flash a Link build from this branch and confirm keycodes land on the expected physical keys in ZMK Studio
  - [ ] Press keys on the physical keyboard and verify output matches the keymap (e.g. outer-left pinky produces `` `
  ``, middle-column top produces `3`)
  - [ ] Confirm encoder push buttons still trigger MUTE / PLAY-PAUSE